### PR TITLE
Add a way to arbitrarily combine controllers

### DIFF
--- a/include/bee/control/combined.hpp
+++ b/include/bee/control/combined.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <functional>
+#include "bee/control/controller.hpp"
+
+namespace bee {
+
+template <typename Input, typename Output, typename... Controllers> class CombinedControllers
+    : public Controller<Input, Output> {
+        std::tuple<Controllers...> controllers;
+        std::function<Output(Input, std::tuple<Controllers...>)> combine;
+    public:
+        static_assert(
+            (is_controller<Controllers>::value && ...),
+            "Controller types passed to CombinedControllers must implement the Controller<Input, Output> interface");
+
+        CombinedControllers(std::tuple<Controllers...> controllers,
+                            std::function<Output(Input, std::tuple<Controllers...>)> combine)
+            : controllers(controllers),
+              combine(combine) {}
+
+        Output update(Input input) override { return combine(input, controllers); }
+
+        void reset() override {
+            std::apply([](auto&... tuple) { (tuple.reset(), ...); }, controllers);
+        }
+};
+
+} // namespace bee

--- a/include/bee/control/controller.hpp
+++ b/include/bee/control/controller.hpp
@@ -6,7 +6,17 @@ namespace bee {
 template <typename Input, typename Output> class Controller {
     public:
         virtual Output update(Input input) = 0;
-        
+
         virtual void reset() = 0;
 };
+
+inline std::false_type is_controller_impl(...) { return std::false_type(); };
+
+template <typename Input, typename Output>
+inline std::true_type is_controller_impl(Controller<Input, Output> const volatile&) {
+    return std::true_type();
+};
+
+template <typename T> using is_controller = decltype(is_controller_impl(std::declval<T&>()));
+
 } // namespace bee


### PR DESCRIPTION
Add the `CombinedControllers` class, which takes any number of controllers and a user-specified function that describes how to combine them.

If any of the controller types passed to `CombinedControllers` do not implement the `Controller<Input, Output` interface, a nice error message is shown.